### PR TITLE
Рекомендуемые изменения

### DIFF
--- a/01/lib/raii_action.hpp
+++ b/01/lib/raii_action.hpp
@@ -19,8 +19,10 @@ private:
 
 public:
     RAIIAction(T _func) : func(_func) {}
-    RAIIAction& operator=(const RAIIAction& src);
+    RAIIAction(const RAIIAction&) = delete;
     RAIIAction(RAIIAction&&) = delete;
+    RAIIAction& operator=(const RAIIAction&) = delete;
+    RAIIAction& operator=(RAIIAction&&) = delete;
 
     ~RAIIAction();
 
@@ -32,15 +34,6 @@ public:
     friend std::ostream& operator<<(std::ostream& out, const RAIIAction<U>& obj);
 
 };
-
-template <callable T>
-RAIIAction<T>& RAIIAction<T>::operator=(const RAIIAction& src)
-{
-    if (&src == this) { return *this; }
-
-    func = src.func;
-    return *this;
-}
 
 
 // #include "raii_action.cpp"

--- a/01/tests/unit/test_raii_action.cpp
+++ b/01/tests/unit/test_raii_action.cpp
@@ -2,6 +2,7 @@
 #include "raii_action.hpp"
 #include "utils.hpp"
 #include <sstream>
+#include <type_traits>
 
 
 TEST(TestRAIIAction, DefaultConstructor)
@@ -27,20 +28,53 @@ TEST(TestRAIIAction, CopyConstructor)
     auto lambda1 = [&someResource](int x) {
         return some_free(someResource, x);
     };
-    auto lambda2 = [&someResource](int x) {
-        return some_free(someResource, x);
-    };
 
     RAIIAction<std::function<int()>> sample1(
         std::bind(lambda1, 1)
     );
-    RAIIAction<std::function<int()>> sample2(
-        std::bind(lambda2, 2)
-    );
 
-    sample1 = sample2;
-
-    std::ostringstream oss;
-    oss << sample1 << sample2;
-    EXPECT_EQ(oss.str(), "22");
+ 	EXPECT_FALSE(std::is_copy_constructible<RAIIAction<std::function<int()>>>::value);
 }
+
+TEST(TestRAIIAction, EffectOfWrappedFunction) {
+    bool isCalled = false;
+
+    auto func = [&isCalled]() {
+        isCalled = true;
+    };
+
+    {
+        auto sample = RAIIAction<std::function<void()>>(std::bind(func));
+    }
+
+    // проверим что функция исполнилась
+    EXPECT_TRUE(isCalled);
+}
+
+TEST(TestRAIIAction, CopyOperator)
+{
+    auto lambda1 = []() {;};
+    
+    auto sample1 = RAIIAction<std::function<void()>>(std::bind(lambda1));
+
+	EXPECT_FALSE(std::is_copy_assignable<RAIIAction<std::function<int()>>>::value);
+}
+
+TEST(TestRAIIAction, MoveConstructor)
+{
+    auto lambda1 = []() {;};
+    
+    auto sample1 = RAIIAction<std::function<void()>>(std::bind(lambda1));
+
+	EXPECT_FALSE(std::is_move_constructible<RAIIAction<std::function<int()>>>::value);
+}
+
+TEST(TestRAIIAction, MoveOperator)
+{
+    auto lambda1 = []() {;};
+    
+    auto sample1 = RAIIAction<std::function<void()>>(std::bind(lambda1));
+
+	EXPECT_FALSE(std::is_move_assignable<RAIIAction<std::function<int()>>>::value);
+}
+


### PR DESCRIPTION
Есть нетривиальный деструктор, должны быть реализованы или удалены конструкторы/операторы перемещения/копирования, в данном случае конструктор перемещения помечен `= delete;`, но только он

Конструктор копирования не указан, поэтому при попытке его вызвать будет использован `std::memmove` для копирования байтов, возможно это может привести к каким-то нежелательным последствиям, поэтому следует его удалить тоже

Тесты для конструктора/оператора перемещения не проходят без исправлений ниже, т.к. проверяется что класс не поддерживает данные методы.

Можно сделать так:
```cpp
RAIIAction(const RAIIAction&) = delete;
RAIIAction(RAIIAction&&) = delete;
RAIIAction& operator=(const RAIIAction&) = delete;
RAIIAction& operator=(RAIIAction&&) = delete;
```

текущую имплементацию `operator=(const RAIIAction&)` стоит удалить
оставить только в самом классе `= delete`

Документации текущая имплементация удовлетворяет